### PR TITLE
Session 2, Exercise 4.6 Typo Fixed

### DIFF
--- a/courses/rust cryptography engineering/course-2022-11-25 Session 2 Notes.md
+++ b/courses/rust cryptography engineering/course-2022-11-25 Session 2 Notes.md
@@ -83,7 +83,7 @@ was generated with the 256-bit AES key (also in hex)
 ```
 using CBC mode with a random IV. The IV is included at the beginning of the ciphertext. Decrypt this ciphertext. You may use an existing cryptography library for this exercise.
 
-6; Let $P_1$, $P_2$ be a message that is two blocks long, and let $P'_1$ be a message that is one block long. Let $C_0, C_1, C_2$ be the encryption of $P_1, P_2$ using CBC mode with a random IV and a random key, and let $C'_0, C'_1$ be the encryption of $P'_1$ using CBC mode with a random IV and the same key. Suppose an attacker knows $P_1, P_2$ and suppose the attacker intercepted and thus know $C_0, C_1, C_2$ and $C_0, C_1$. Further suppose that, by random chance, $C_1 = C_2$. Show that the attacker can compute $P'_1$.
+6; Let $P_1$, $P_2$ be a message that is two blocks long, and let $P'_1$ be a message that is one block long. Let $C_0, C_1, C_2$ be the encryption of $P_1, P_2$ using CBC mode with a random IV and a random key, and let $C'_0, C'_1$ be the encryption of $P'_1$ using CBC mode with a random IV and the same key. Suppose an attacker knows $P_1, P_2$ and suppose the attacker intercepted and thus know $C_0, C_1, C_2$ and $C'_0, C'_1$. Further suppose that, by random chance, $C'_1 = C_2$. Show that the attacker can compute $P'_1$.
 - Implement a pair of functions: A [PKCS](https://en.wikipedia.org/wiki/PKCS_7) message padding function, and a padding validation function that takes a message and validates whether it has a correct padding.
 
 ### Extra Reading:


### PR DESCRIPTION
It should be $C'_1 =C_2$, not $C_1=C_2$