### PR TITLE
chore: fix latex formula

### DIFF
--- a/courses/rust cryptography engineering/course-2023-02-17 Session 12 Notes.md
+++ b/courses/rust cryptography engineering/course-2023-02-17 Session 12 Notes.md
@@ -36,6 +36,7 @@ $$\begin{align}
 r&= (g^k\mod p)&&\mod q \qquad  \text{r is a blind for the secret key}\\
 s&= k^{-1}(H(m)+xr)&&\mod q  \qquad   \text{(r,s) is the signature}
  \end{align}$$
+
 The $k^{-1}$ step makes ECDSA inflexible to many desirable adjustments in the algorithm.
 
 ### ECDSA verification:
@@ -61,7 +62,9 @@ $$\begin{align}
 r&=g^k&&\mod q\\
 e&=H(r||M) &&\mod q \quad \text{|| denotes bit-string concatenation}\\
 s&=k-xe && \mod q \quad \text{(e,s) is the signature}
- \end{align}$$ Note that $s$ is linear in $x$. This is what makes Schnorr flexible to algebraic adjustments.
+ \end{align}$$
+
+Note that $s$ is linear in $x$. This is what makes Schnorr flexible to algebraic adjustments.
 
 ### Schnorr verification
 With knowledge of public key $X$ and signature $(e,s)$, the verifier computes:


### PR DESCRIPTION
The note under the formula is mixed with the formula. 
![image](https://user-images.githubusercontent.com/33206087/224283783-9d651a70-9e62-44d0-b8ec-c12dc0c40841.png)

Inserting a line might solve the problem.

Note that it looked fine without the fix on my local `Obsidian` instance, so it may be related to `Obsidian Publish`.
