### PR TITLE
fix: link to moon 

### DIFF
--- a/courses/rust cryptography engineering/course-2023-03-17 Session 14 Notes.md
+++ b/courses/rust cryptography engineering/course-2023-03-17 Session 14 Notes.md
@@ -8,7 +8,7 @@ tags: type/context/course
 - prev:: [[course-2023-02-24 Session 13 Notes]]
 - next:: [[course-2023-03-24 Session 16 Notes]]
 ## Discussion
-This week will cover ZK at a high level, specifically ZK circuits and emerging applications. We will specifically cover Schnorr's $\Sigma$ protocol for proof of knowledge of Exponent. ZK is a large topic, the interested reader is directed to the [Moon Math Manual](https://raw.githubusercontent.com/LeastAuthority/moonmath-manual/main/main-moonmath.pdf) and [Proofs, Arguments, and Zero Knowledge](https://people.cs.georgetown.edu/jthaler/ProofsArgsAndZK.pdf).
+This week will cover ZK at a high level, specifically ZK circuits and emerging applications. We will specifically cover Schnorr's $\Sigma$ protocol for proof of knowledge of Exponent. ZK is a large topic, the interested reader is directed to the [Moon Math Manual](https://github.com/LeastAuthority/moonmath-manual/releases/latest/download/main-moonmath.pdf) and [Proofs, Arguments, and Zero Knowledge](https://people.cs.georgetown.edu/jthaler/ProofsArgsAndZK.pdf).
 
 ---
 ## Topic


### PR DESCRIPTION
Fix link to Moon Math Tutorial. Link is broken